### PR TITLE
update

### DIFF
--- a/index.html
+++ b/index.html
@@ -1280,6 +1280,6 @@
         <button id="backToTop" aria-label="Remonter en haut">
             <i class="fa-solid fa-chevron-up"></i>
         </button>
-        <script src="script.js?v=8"></script>
+        <script src="script.js?v=9"></script>
     </body>
 </html>


### PR DESCRIPTION
## Changements

- Passe le cache-buster de `script.js?v=8` à `script.js?v=9` pour forcer le navigateur à charger la version où l'animation console affiche `Zyranex`.

## Validation

- `npx --yes htmlhint index.html`
- `node --check script.js`
- Recherche locale: aucune occurrence applicative de `Galactic`, `galactic`, `SMP` ou `smp`.