### PR TITLE
Update portfolio links to BenchSift

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The site is **bilingual (FR/EN)** — change the language in the navigation bar.
 
 - **[NxtGit](https://nxtgit.nxtaigen.com/)** — Lightweight GitHub client for macOS/Windows: cloning, committing, diffing — no browser required
 
-- **[Nxt AI Card](https://nxtaicard.nxtaigen.com/)** — Dashboard comparing AI models: performance, price, and speed Real-time updates
+- **[BenchSift](https://benchsift.nxtaigen.com/)** — Dashboard comparing AI models: performance, price, and speed Real-time updates
 - **[NxtUpdate](https://github.com/scorpion7slayer/NxtUpdate)** — Updates Homebrew, Node, Python, Rust, and macOS from a single terminal.
 
 ## Technology Stack

--- a/index.html
+++ b/index.html
@@ -693,7 +693,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <!-- Card 5 : Nxt AI Card -->
+                                <!-- Card 5 : BenchSift -->
                                 <div class="project-card">
                                     <div class="project-card-bar">
                                         <div class="terminal-buttons">
@@ -708,21 +708,21 @@
                                             ></span>
                                         </div>
                                         <span class="project-card-filename"
-                                            >NxtAICard.js</span
+                                            >BenchSift.js</span
                                         >
                                     </div>
                                     <div class="project-card-img-wrap">
                                         <img
                                             src="assets/screenshots/NxtAICard.webp"
                                             class="project-card-img"
-                                            alt="Comparateur de modèles IA Nxt AI Card"
+                                            alt="Comparateur de modèles IA BenchSift"
                                             loading="lazy"
                                             decoding="async"
                                         />
                                     </div>
                                     <div class="project-card-body">
                                         <h5 class="project-card-title">
-                                            Nxt AI Card
+                                            BenchSift
                                         </h5>
                                         <p
                                             class="project-card-desc"
@@ -734,7 +734,7 @@
                                         </p>
                                         <div class="project-links d-flex gap-2">
                                             <a
-                                                href="https://github.com/scorpion7slayer/nxtaicard"
+                                                href="https://github.com/scorpion7slayer/benchsift"
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 aria-label="Voir le code source"
@@ -745,7 +745,7 @@
                                                 ></i>
                                             </a>
                                             <a
-                                                href="https://nxtaicard.nxtaigen.com/"
+                                                href="https://benchsift.nxtaigen.com/"
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 aria-label="Visiter le site web"

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://theo.nxtaigen.com/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## What changed
- replace outdated NxtAICard links and labels with BenchSift
- point project links to the current BenchSift site and repository
- refresh the portfolio sitemap last-modified date

## Why
Google Search Console still discovers the retired NxtAICard hostname. Updating the portfolio strengthens the canonical BenchSift domain and removes an obsolete crawl source.

## Validation
- `xmllint --noout sitemap.xml`
- `git diff --check`
- confirmed no remaining `nxtaicard.nxtaigen.com` links in the site files