### PR TITLE
Update cache-busting versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
             integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
             crossorigin="anonymous"
         />
-        <link href="style.css?v=17" rel="stylesheet" />
+        <link href="style.css?v=18" rel="stylesheet" />
         <link
             rel="stylesheet"
             href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
@@ -1356,6 +1356,6 @@
         <button id="backToTop" aria-label="Remonter en haut">
             <i class="fa-solid fa-chevron-up"></i>
         </button>
-        <script src="script.js?v=13"></script>
+        <script src="script.js?v=18"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- bump the stylesheet cache-busting version from 17 to 18
- bump the JavaScript cache-busting version from 13 to 18

## Validation
- verified the branch contains only the intended `index.html` changes
- `git diff --check` passes

## Impact
Browsers will fetch the latest local CSS and JavaScript assets instead of reusing stale cached versions.