### PR TITLE
Update Flavortown project to Stardance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The site is **bilingual (FR/EN)** — change the language in the navigation bar.
 
 ## Featured Projects
 
-- **[flavortown-github-exporter](https://github.com/scorpion7slayer/flavortown-github-exporter)** — Chrome and Firefox extension for submitting GitHub projects to Flavortown with one click
+- **[stardance-github-exporter](https://github.com/scorpion7slayer/stardance-github-exporter)** — Chrome and Firefox extension for importing GitHub repositories into Stardance with one click
 
 - **[NxtAIGen](https://github.com/scorpion7slayer/NxtAIGen)** — Multi-model AI chatbot (GPT, Claude, Mistral) from a single interface
 

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
             integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
             crossorigin="anonymous"
         />
-        <link href="style.css?v=19" rel="stylesheet" />
+        <link href="style.css?v=20" rel="stylesheet" />
         <link
             rel="stylesheet"
             href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
@@ -880,7 +880,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <!-- Card 8 : Flavortown -->
+                                <!-- Card 8 : Stardance -->
                                 <div class="project-card">
                                     <div class="project-card-bar">
                                         <div class="terminal-buttons">
@@ -895,14 +895,14 @@
                                             ></span>
                                         </div>
                                         <span class="project-card-filename"
-                                            >flavortown.js</span
+                                            >stardance.js</span
                                         >
                                     </div>
                                     <div class="project-card-img-wrap">
                                         <img
                                             src="assets/screenshots/extension-flavortown.webp"
                                             class="project-card-img"
-                                            alt="Extension web Flavortown GitHub Exporter pour Chrome"
+                                            alt="Extension web Stardance GitHub Importer pour Chrome"
                                             loading="lazy"
                                             decoding="async"
                                         />
@@ -911,23 +911,19 @@
                                         <h5
                                             class="project-card-title d-flex align-items-center flex-wrap gap-2"
                                         >
-                                            flavortown github export
-                                            <span
-                                                class="badge badge-ferme rounded-pill"
-                                                >Fermé</span
-                                            >
+                                            stardance github importer
                                         </h5>
                                         <p
                                             class="project-card-desc"
                                             data-i18n="proj-1-desc"
                                         >
                                             Extension Chrome &amp; Firefox pour
-                                            exporter vos projets GitHub vers
-                                            Flavortown en un clic.
+                                            importer vos dépôts GitHub dans
+                                            Stardance en un clic.
                                         </p>
                                         <div class="project-links d-flex gap-2">
                                             <a
-                                                href="https://github.com/scorpion7slayer/flavortown-github-exporter"
+                                                href="https://github.com/scorpion7slayer/stardance-github-exporter"
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 aria-label="Voir le code source"
@@ -1027,7 +1023,7 @@
                                     <span>Chrome</span>
                                 </a>
                                 <a
-                                    href="https://addons.mozilla.org/fr/firefox/addon/flavortown-github-exporter/"
+                                    href="https://addons.mozilla.org/fr/firefox/addon/stardance-github-importer/"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     class="browser-choice"
@@ -1294,6 +1290,6 @@
         <button id="backToTop" aria-label="Remonter en haut">
             <i class="fa-solid fa-chevron-up"></i>
         </button>
-        <script src="script.js?v=19"></script>
+        <script src="script.js?v=20"></script>
     </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -18,7 +18,7 @@ var TRANSLATIONS = {
         "proj-nxtaigen-desc":
             "Projets open source pour GitHub, l’IA et le terminal.",
         "proj-1-desc":
-            "Extension Chrome & Firefox pour exporter vos projets GitHub vers Flavortown en un clic.",
+            "Extension Chrome & Firefox pour importer vos d\u00e9p\u00f4ts GitHub dans Stardance en un clic.",
         "proj-2-desc":
             "Chatbot web multi-mod\u00e8les\u00a0: GPT, Claude, Mistral.",
         "proj-3-desc":
@@ -83,7 +83,7 @@ var TRANSLATIONS = {
         "proj-nxtaigen-desc":
             "Open-source projects for GitHub, AI and the terminal.",
         "proj-1-desc":
-            "Chrome & Firefox extension to submit your GitHub projects to Flavortown in one click.",
+            "Chrome & Firefox extension to import your GitHub repositories into Stardance in one click.",
         "proj-2-desc": "Multi-model web chatbot: GPT, Claude, Mistral.",
         "proj-3-desc":
             "Lightweight GitHub client for macOS/Windows: clone, commit, diff \u2014 no browser needed.",

--- a/style.css
+++ b/style.css
@@ -287,16 +287,6 @@ body {
     letter-spacing: 0.02em;
 }
 
-.badge-ferme {
-    padding: 0.4em 0.7em;
-    background-color: rgba(220, 53, 69, 0.12);
-    border: 1px solid rgba(220, 53, 69, 0.35);
-    color: #ff6b6b;
-    font-size: 0.62rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
-}
-
 .badge-indisponible {
     padding: 0.4em 0.7em;
     background-color: rgba(108, 117, 125, 0.12);


### PR DESCRIPTION
## What changed

- Rename the Flavortown project card to Stardance GitHub Importer
- Remove the closed status badge and its unused styling
- Update the GitHub and Firefox extension links
- Refresh French and English descriptions in the portfolio and README
- Bump the static asset cache version to `v20`

## Why

The browser extension migrated from the retired Flavortown project to Stardance and is now publicly available under a new GitHub repository and Firefox listing.

## Impact

Portfolio visitors now see the current project name, availability, description, and installation links.

## Validation

- `node --check script.js`
- `git diff --check`
