### PR TITLE
Add Market Plier team details and clean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,3 @@ sitemap.xml SEO
 - Portfolio: [theo.nxtaigen.com](https://theo.nxtaigen.com/)
 
 - GitHub: [github.com/scorpion7slayer](https://github.com/scorpion7slayer)
-
----
-
-[![Sponsorship badge DigitalOcean](https://web-platforms.sfo2.cdn.digitaloceanspaces.com/WWW/Badge%201.svg)](https://www.digitalocean.com/?refcode=cb3c5c7ece01&utm_campaign=Referral_Invite&utm_medium=Referral_Program&utm_source=badge)

--- a/index.html
+++ b/index.html
@@ -845,6 +845,17 @@
                                                 class="badge badge-indisponible rounded-pill"
                                                 >Indisponible</span
                                             >
+                                            <span
+                                                class="badge badge-group-project rounded-pill"
+                                            >
+                                                <i
+                                                    class="fa-solid fa-user-group"
+                                                    aria-hidden="true"
+                                                ></i>
+                                                <span data-i18n="project-group"
+                                                    >Projet de groupe</span
+                                                >
+                                            </span>
                                         </h5>
                                         <p
                                             class="project-card-desc"
@@ -856,14 +867,15 @@
                                         </p>
                                         <div class="project-links d-flex gap-2">
                                             <a
-                                                href="https://github.com/scorpion7slayer/market-plier"
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                aria-label="Voir le code source"
-                                                title="Voir le code source"
+                                                href="#marketPlierGithubModal"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#marketPlierGithubModal"
+                                                aria-label="Voir l’équipe GitHub de Market Plier"
+                                                title="Voir l’équipe GitHub"
                                             >
                                                 <i
                                                     class="fa-brands fa-github text-white"
+                                                    aria-hidden="true"
                                                 ></i>
                                             </a>
                                             <a
@@ -1063,6 +1075,130 @@
                                 <span data-i18n="modal-nxtaigen-unavailable"
                                     >site web indisponible pour le moment</span
                                 >
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <!-- Modal équipe GitHub Market Plier -->
+            <div
+                class="modal fade"
+                id="marketPlierGithubModal"
+                tabindex="-1"
+                aria-labelledby="marketPlierGithubModalLabel"
+                aria-describedby="marketPlierGithubDescription"
+                aria-hidden="true"
+            >
+                <div class="modal-dialog modal-dialog-centered modal-lg">
+                    <div
+                        class="modal-content browser-modal-content project-team-modal"
+                    >
+                        <div class="modal-header border-0">
+                            <h5
+                                class="modal-title"
+                                id="marketPlierGithubModalLabel"
+                                data-i18n="marketplier-team-title"
+                            >
+                                L’équipe de Market Plier
+                            </h5>
+                            <button
+                                type="button"
+                                class="btn-close btn-close-white"
+                                data-bs-dismiss="modal"
+                                aria-label="Fermer"
+                            ></button>
+                        </div>
+                        <div class="modal-body project-team-body">
+                            <p
+                                class="project-team-intro"
+                                id="marketPlierGithubDescription"
+                                data-i18n="marketplier-team-intro"
+                            >
+                                Un projet construit à trois. Découvre les
+                                profils des développeurs ou consulte directement
+                                le dépôt.
+                            </p>
+                            <div class="project-team-list">
+                                <a
+                                    class="project-collaborator"
+                                    href="https://github.com/scorpion7slayer"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    aria-label="GitHub de scorpion7slayer"
+                                >
+                                    <img
+                                        src="https://github.com/scorpion7slayer.png?size=160"
+                                        alt="Photo de profil GitHub de scorpion7slayer"
+                                        width="72"
+                                        height="72"
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                    <span>@scorpion7slayer</span>
+                                    <i
+                                        class="fa-solid fa-arrow-up-right-from-square"
+                                        aria-hidden="true"
+                                    ></i>
+                                </a>
+                                <a
+                                    class="project-collaborator"
+                                    href="https://github.com/Gaspami"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    aria-label="GitHub de Gaspami"
+                                >
+                                    <img
+                                        src="https://github.com/Gaspami.png?size=160"
+                                        alt="Photo de profil GitHub de Gaspami"
+                                        width="72"
+                                        height="72"
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                    <span>@Gaspami</span>
+                                    <i
+                                        class="fa-solid fa-arrow-up-right-from-square"
+                                        aria-hidden="true"
+                                    ></i>
+                                </a>
+                                <a
+                                    class="project-collaborator"
+                                    href="https://github.com/dayko555"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    aria-label="GitHub de dayko555"
+                                >
+                                    <img
+                                        src="https://github.com/dayko555.png?size=160"
+                                        alt="Photo de profil GitHub de dayko555"
+                                        width="72"
+                                        height="72"
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                    <span>@dayko555</span>
+                                    <i
+                                        class="fa-solid fa-arrow-up-right-from-square"
+                                        aria-hidden="true"
+                                    ></i>
+                                </a>
+                            </div>
+                            <div class="project-repo-action">
+                                <a
+                                    class="btn btn-primary project-repo-link"
+                                    href="https://github.com/scorpion7slayer/market-plier"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    aria-label="Dépôt GitHub de Market Plier"
+                                >
+                                    <i
+                                        class="fa-brands fa-github"
+                                        aria-hidden="true"
+                                    ></i>
+                                    <span data-i18n="marketplier-repo-link"
+                                        >Voir le dépôt du projet</span
+                                    >
+                                </a>
                             </div>
                         </div>
                     </div>

--- a/script.js
+++ b/script.js
@@ -27,6 +27,11 @@ var TRANSLATIONS = {
             "Dashboard comparant les mod\u00e8les IA\u00a0: benchmarks, prix et vitesse en temps r\u00e9el.",
         "proj-6-desc":
             "Marketplace web avec cat\u00e9gories, articles tendances et derni\u00e8res annonces.",
+        "project-group": "Projet de groupe",
+        "marketplier-team-title": "L\u2019\u00e9quipe de Market Plier",
+        "marketplier-team-intro":
+            "Un projet construit \u00e0 trois. D\u00e9couvre les profils des d\u00e9veloppeurs ou consulte directement le d\u00e9p\u00f4t.",
+        "marketplier-repo-link": "Voir le d\u00e9p\u00f4t du projet",
         "proj-7-desc":
             "Outil en ligne de commande pour mettre \u00e0 jour tous tes paquets en une seule fois.",
         "proj-8-desc":
@@ -91,6 +96,11 @@ var TRANSLATIONS = {
             "Dashboard comparing AI models: benchmarks, pricing and speed in real time.",
         "proj-6-desc":
             "Web marketplace with categories, trending items and latest listings.",
+        "project-group": "Group project",
+        "marketplier-team-title": "The Market Plier team",
+        "marketplier-team-intro":
+            "A project built by three developers. Explore their profiles or go directly to the repository.",
+        "marketplier-repo-link": "View the project repository",
         "proj-7-desc": "Command-line tool to update all your packages at once.",
         "proj-8-desc":
             "Pixel-art website for a Minecraft Java server: presentation, status and Discord access.",

--- a/style.css
+++ b/style.css
@@ -297,6 +297,19 @@ body {
     letter-spacing: 0.02em;
 }
 
+.badge-group-project {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4em 0.7em;
+    background-color: rgba(13, 110, 253, 0.14);
+    border: 1px solid rgba(94, 159, 255, 0.42);
+    color: #9bc2ff;
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
 /* Carrousel projets */
 .projects-carousel-outer {
     position: relative;
@@ -450,6 +463,12 @@ body {
     transform: translateY(-1px);
     filter: brightness(1.2);
     border-color: rgba(229, 228, 226, 0.3);
+}
+
+.project-links a:focus-visible,
+.project-collaborator:focus-visible {
+    outline: 3px solid #ffc107;
+    outline-offset: 2px;
 }
 
 /* Boutons de navigation carrousel */
@@ -895,6 +914,123 @@ body.lightbox-open {
 
 .browser-choice span {
     font-weight: 500;
+}
+
+/* Équipe Market Plier */
+.project-team-modal {
+    overflow: hidden;
+}
+
+.project-team-body {
+    padding: 0 1.5rem 1.5rem;
+}
+
+.project-team-intro {
+    max-width: 62ch;
+    margin: 0 0 1.25rem;
+    color: rgba(229, 228, 226, 0.76);
+    font-size: 0.88rem;
+    line-height: 1.65;
+}
+
+.project-team-list {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.project-collaborator {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.65rem;
+    min-width: 0;
+    padding: 1.15rem 0.75rem;
+    border: 1px solid rgba(229, 228, 226, 0.12);
+    border-radius: 0.75rem;
+    background-color: rgba(229, 228, 226, 0.045);
+    color: #e5e4e2;
+    text-align: center;
+    text-decoration: none;
+    transition:
+        transform 0.18s ease-out,
+        background-color 0.18s ease-out,
+        border-color 0.18s ease-out;
+}
+
+.project-collaborator:hover {
+    transform: translateY(-2px);
+    border-color: rgba(94, 159, 255, 0.58);
+    background-color: rgba(13, 110, 253, 0.1);
+    color: #ffffff;
+}
+
+.project-collaborator img {
+    width: 4.5rem;
+    height: 4.5rem;
+    border-radius: 50%;
+    object-fit: cover;
+    background-color: #252423;
+}
+
+.project-collaborator span {
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    font-size: 0.82rem;
+    font-weight: 600;
+}
+
+.project-collaborator i {
+    position: absolute;
+    top: 0.7rem;
+    right: 0.7rem;
+    color: rgba(229, 228, 226, 0.45);
+    font-size: 0.68rem;
+}
+
+.project-repo-action {
+    display: flex;
+    justify-content: center;
+    margin-top: 1.25rem;
+}
+
+.project-repo-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    min-height: 2.75rem;
+    padding-inline: 1.1rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+@media (max-width: 575.98px) {
+    .project-team-body {
+        padding: 0 1rem 1rem;
+    }
+
+    .project-team-list {
+        grid-template-columns: 1fr;
+    }
+
+    .project-collaborator {
+        flex-direction: row;
+        justify-content: flex-start;
+        padding: 0.8rem;
+        text-align: left;
+    }
+
+    .project-collaborator img {
+        width: 3rem;
+        height: 3rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .project-collaborator {
+        transition: none;
+    }
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary

- add a bilingual group-project badge to the Market Plier card
- show the three developers with GitHub avatars and profile links in an accessible responsive modal
- add a dedicated button to the Market Plier repository
- remove the DigitalOcean sponsorship badge from the README

## Impact

Visitors can immediately identify Market Plier as a collaborative project and discover every contributor without losing access to the project repository.

## Validation

- `node --check script.js`
- HTMLHint on `index.html`
- CSSTree Validator on `style.css`
- FR/EN translation coverage and parity check
- `git diff --check`