### PR TITLE
Fix Nxtaigen project image

### DIFF
--- a/index.html
+++ b/index.html
@@ -469,7 +469,7 @@
                                     </div>
                                     <div class="project-card-img-wrap">
                                         <img
-                                            src="assets/screenshots/nxtaigen.webp"
+                                            src="assets/screenshots/NxtAIGen.webp"
                                             class="project-card-img"
                                             alt="Site vitrine des projets open source Nxtaigen"
                                             loading="lazy"


### PR DESCRIPTION
## Summary

- point the Nxtaigen project card to the existing `NxtAIGen.webp` screenshot
- restore the screenshot instead of the broken-image fallback

## Root cause

The markup referenced `assets/screenshots/nxtaigen.webp`, but the tracked file is case-sensitive and named `assets/screenshots/NxtAIGen.webp`. The missing URL returned the HTML fallback instead of an image.

## Impact

The Nxtaigen card now displays its real project screenshot on case-sensitive production hosting.

## Validation

- `node --check script.js`
- `npx --yes htmlhint index.html`
- `git diff --check`
- local HTTP response: `200 image/webp`
- visual verification in Chrome