### PR TITLE
Met à jour le statut et la démo de NxtGit

### DIFF
--- a/index.html
+++ b/index.html
@@ -667,7 +667,7 @@
                                     </div>
                                     <div class="project-card-body">
                                         <h5
-                                            class="project-card-title d-flex align-items-center"
+                                            class="project-card-title d-flex align-items-center flex-wrap"
                                         >
                                             NxtGit
                                             <span
@@ -681,6 +681,11 @@
                                             <span
                                                 class="badge badge-os badge-os-small rounded-pill ms-1"
                                                 >Windows</span
+                                            >
+                                            <span
+                                                class="badge badge-archived rounded-pill ms-1"
+                                                data-i18n="project-archived"
+                                                >Archivé</span
                                             >
                                         </h5>
                                         <p
@@ -726,14 +731,14 @@
                                                 ></i>
                                             </a>
                                             <a
-                                                href="https://youtu.be/W2mVp_yVHcA"
+                                                href="https://cap.so/s/9knyk9srj09a7st"
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 aria-label="Voir la vidéo de démonstration"
                                                 title="Voir la vidéo de démonstration"
                                             >
                                                 <i
-                                                    class="fa-brands fa-youtube text-white"
+                                                    class="fa-solid fa-video text-white"
                                                 ></i>
                                             </a>
                                         </div>

--- a/script.js
+++ b/script.js
@@ -28,6 +28,7 @@ var TRANSLATIONS = {
         "proj-6-desc":
             "Marketplace web avec cat\u00e9gories, articles tendances et derni\u00e8res annonces.",
         "project-group": "Projet de groupe",
+        "project-archived": "Archivé",
         "marketplier-team-title": "L\u2019\u00e9quipe de Market Plier",
         "marketplier-team-intro":
             "Un projet construit \u00e0 trois. D\u00e9couvre les profils des d\u00e9veloppeurs ou consulte directement le d\u00e9p\u00f4t.",
@@ -97,6 +98,7 @@ var TRANSLATIONS = {
         "proj-6-desc":
             "Web marketplace with categories, trending items and latest listings.",
         "project-group": "Group project",
+        "project-archived": "Archived",
         "marketplier-team-title": "The Market Plier team",
         "marketplier-team-intro":
             "A project built by three developers. Explore their profiles or go directly to the repository.",

--- a/style.css
+++ b/style.css
@@ -297,6 +297,16 @@ body {
     letter-spacing: 0.02em;
 }
 
+.badge-archived {
+    padding: 0.4em 0.7em;
+    background-color: rgba(255, 193, 7, 0.12);
+    border: 1px solid rgba(255, 193, 7, 0.35);
+    color: #ffd76a;
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
 .badge-group-project {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Changements

- Ajoute une pill jaune « Archivé » à NxtGit, avec traduction française et anglaise.
- Remplace le lien YouTube par le partage Cap.so.
- Remplace l’icône YouTube par une icône vidéo générique.
- Autorise les badges du titre NxtGit à passer à la ligne sur les petits écrans.

## Impact

Le statut archivé est plus visible et la démonstration pointe désormais vers la nouvelle capture Cap.so.

## Vérifications

- `node --check script.js`
- `git diff --check`
- Vérification du périmètre : seuls `index.html`, `script.js` et `style.css` sont inclus dans le commit.